### PR TITLE
Add HTML decoding of URL titles.

### DIFF
--- a/Gthx.Bot/GthxBot.cs
+++ b/Gthx.Bot/GthxBot.cs
@@ -10,7 +10,7 @@ namespace Gthx.Bot
 {
     public class GthxBot
     {
-        public static readonly string Version = "2.20 2021-09-13";
+        public static readonly string Version = "2.21 2021-09-21";
 
         private readonly List<IGthxModule> _Modules;
         private readonly IBotNick _botNick;

--- a/Gthx.Bot/GthxUtil.cs
+++ b/Gthx.Bot/GthxUtil.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 using Gthx.Bot.Interfaces;
 using Microsoft.Extensions.Logging;
 
@@ -129,6 +130,8 @@ namespace Gthx.Bot
 
             _logger.LogInformation("Finished waiting for the web stream...");
 
+            string? encodedTitle = null;
+
             using var reader = new StreamReader(webStream);
             while (!reader.EndOfStream)
             {
@@ -142,18 +145,25 @@ namespace Gthx.Bot
                 if (titleMatch.Success)
                 {
                     _logger.LogInformation("Found title: {Title}", titleMatch.Groups["title"].Value);
-                    return titleMatch.Groups["title"].Value;
+                    encodedTitle = titleMatch.Groups["title"].Value;
+                    break;
                 }
 
                 var metaMatch = _metaRegex.Match(line);
                 if (metaMatch.Success)
                 {
                     _logger.LogInformation("Found meta title: {Title}", metaMatch.Groups["title"].Value);
-                    return metaMatch.Groups["title"].Value;
+                    encodedTitle = metaMatch.Groups["title"].Value;
+                    break;
                 }
             }
 
-            return string.Empty;
+            if (encodedTitle == null)
+            {
+                return string.Empty;
+            }
+
+            return HttpUtility.HtmlDecode(encodedTitle);
         }
 
     }

--- a/Gthx.Test/GthxTests.cs
+++ b/Gthx.Test/GthxTests.cs
@@ -513,6 +513,15 @@ namespace Gthx.Test
             Assert.AreEqual(testChannel, replies.Channel);
             Assert.AreEqual($"{testUser} linked to YouTube video \"Meta Title\" => 1 IRC mentions", replies.Messages[0]);
 
+            // Test fetching a new title that uses the <meta> element for the title
+            testUser = "QAGuy";
+            _gthx.HandleReceivedMessage(testChannel, testUser, $"Did they fix that bugs with encoded characters? https://youtu.be/encoded");
+            await Task.Delay(500);
+            replies = _client.GetReplies();
+            Assert.AreEqual(1, replies.Messages.Count);
+            Assert.AreEqual(testChannel, replies.Channel);
+            Assert.AreEqual($"{testUser} linked to YouTube video \"Rum & \"Coke\"\" => 1 IRC mentions", replies.Messages[0]);
+
             // Test message when no title is found
             testUser = "AnotherNick";
             _gthx.HandleReceivedMessage(testChannel, testUser, $"Does thie one work for you? https://youtu.be/notitle");

--- a/Gthx.Test/Mocks/MockWebReader.cs
+++ b/Gthx.Test/Mocks/MockWebReader.cs
@@ -31,6 +31,12 @@ namespace Gthx.Test.Mocks
 <meta name=""title"" content=""Meta Title"">
 </head>");
                 }
+                else if (url.EndsWith("/encoded"))
+                {
+                    dataString = utf8Encoding.GetBytes(@"<head>
+<title>Rum &amp; &quot;Coke&quot; - YouTube</title>
+</head>");
+                }
                 else if (url.EndsWith(":2810756"))
                 {
                     dataString = utf8Encoding.GetBytes(@"<head>


### PR DESCRIPTION
Add unit test for HTML encoded URL title.
Bump version to 2.21
Fixes #18